### PR TITLE
Add SEO/funnel/hooks audit and baseline crawl assets

### DIFF
--- a/docs/seo-funnel-hooks-audit.md
+++ b/docs/seo-funnel-hooks-audit.md
@@ -1,0 +1,189 @@
+# SEO, Funnel, and Hook Audit + Optimization Plan
+
+## Scope audited
+- Primary landing experience in `index.html`
+- Existing metadata, schema, conversion points, and CTA structure
+- Current technical constraints (single static page, no build pipeline)
+
+---
+
+## 1) SEO Audit (Current State)
+
+### What is already solid
+- Title, meta description, canonical tag, Open Graph, and Twitter Card tags are present.
+- The page has a single `<h1>` and clear section-level `<h2>` headings.
+- Structured data exists (`MusicGroup`) and includes social profile links.
+- Images include `alt` text and modern lazy/eager loading usage.
+
+### Gaps and risks
+1. **No crawl guidance assets**
+   - Missing `robots.txt` and `sitemap.xml`, reducing crawl discoverability and index freshness signals.
+2. **Structured data depth is limited**
+   - Only one schema node is present; no `WebSite`, `Organization`, or release-level entities (`MusicAlbum`/`MusicRecording`) for rich result opportunities.
+3. **Canonical and OG URL tied to Vercel subdomain**
+   - If a custom domain is intended, this can dilute long-term brand equity.
+4. **Keyword targeting is broad**
+   - Current copy favors brand language but does not systematically target intent clusters:
+     - “D Roc songs”
+     - “I Want It All D Roc”
+     - “Daddy Frequency Productions”
+     - “new hip hop releases”
+5. **No dedicated indexable subpages**
+   - One-page architecture limits topical depth and long-tail ranking potential.
+6. **No explicit performance budget/monitoring**
+   - Three.js background and heavy visuals can hurt mobile CWV if not measured continuously.
+
+---
+
+## 2) Funnel Audit (Current State)
+
+### Existing funnel elements
+- Hero section with release CTA row.
+- Platform cards for listen/watch actions.
+- Project cards for deeper engagement.
+- Newsletter capture form near page bottom.
+
+### Funnel friction observed
+1. **Primary conversion event appears late for email capture**
+   - The newsletter form is below multiple sections, likely reducing mobile conversion.
+2. **Single-step CTA architecture**
+   - Most CTAs route directly out to streaming platforms, with limited owned-audience capture before exit.
+3. **No segmented paths by user intent**
+   - New listeners, returning fans, collaborators, and media are not split into tailored flows.
+4. **No trust/reason-to-subscribe module**
+   - “Join the movement” lacks concrete incentive copy (exclusive drops, early access, private previews).
+5. **No measurable funnel instrumentation plan documented**
+   - Event naming and KPI definitions are not standardized.
+
+---
+
+## 3) Hook Audit (Messaging + Retention Triggers)
+
+### Current strengths
+- Voice is distinct, confident, and brand-consistent.
+- Visual identity and release emphasis create immediate artist positioning.
+
+### Hook opportunities
+1. **No high-clarity value proposition above the fold**
+   - Missing one crisp line that states why a first-time visitor should stay.
+2. **Limited urgency mechanics**
+   - Few timed hooks (countdowns, “new drop this week,” social proof counters).
+3. **No repeat-visit hooks**
+   - No content cadence signal (“new verse every Friday”, “monthly drop schedule”).
+4. **Minimal social proof blocks**
+   - No embed/quotes/playlist adds/press logos to reduce trust gap.
+
+---
+
+## 4) Prioritized 90-Day Plan
+
+## Phase 1 (Week 1–2): Technical SEO + Measurement Foundations
+- Add and maintain `robots.txt` and `sitemap.xml`.
+- Define canonical domain strategy (temporary Vercel vs. permanent custom domain).
+- Expand schema graph:
+  - `WebSite`
+  - `Organization`
+  - `MusicGroup` (existing, refined)
+  - one node per featured release (`MusicAlbum`)
+- Set analytics event taxonomy for funnel metrics:
+  - `hero_cta_click`
+  - `platform_click`
+  - `project_click`
+  - `newsletter_submit`
+  - `newsletter_success`
+  - `newsletter_error`
+
+**Success criteria:**
+- Search Console successfully reads sitemap.
+- Structured data validates in Rich Results test.
+- Core events visible in analytics/debug mode.
+
+## Phase 2 (Week 3–6): Conversion Funnel Upgrades
+- Move/add a compact email CTA above the fold (hero secondary action).
+- Introduce lead magnet copy:
+  - “Get unreleased snippets + drop alerts first.”
+- Add intent segmentation CTAs:
+  - Listener path (stream now)
+  - Superfan path (join list)
+  - Business path (bookings/contact)
+- Add sticky mobile CTA bar for primary action.
+- Add thank-you state with optional second-step conversion (follow on Spotify/YouTube).
+
+**Success criteria:**
+- +20–35% increase in newsletter conversion rate.
+- +15% increase in click-through to primary platform.
+
+## Phase 3 (Week 7–10): Hook System + Content Depth
+- Publish dedicated release pages (`/releases/i-want-it-all`, `/releases/hush`) with unique metadata and schema.
+- Add social proof strip (stream counts, testimonials, notable playlist placements).
+- Add recurring content hook block (“Next drop date”, “Studio log”, “behind-the-scenes clips”).
+- Add internal linking modules between releases/projects.
+
+**Success criteria:**
+- Long-tail impressions increase in Search Console.
+- Returning visitor rate improves by 10–20%.
+
+## Phase 4 (Week 11–13): Optimization Loop
+- Run A/B test on hero headline + CTA text.
+- Run A/B test on newsletter placement and offer language.
+- Tune underperforming platform cards based on click share.
+- Review CWV and reduce animation load if mobile performance regresses.
+
+**Success criteria:**
+- Statistically significant uplift on chosen primary KPI (newsletter CVR or platform CTR).
+
+---
+
+## 5) KPI Dashboard (Recommended)
+
+### Acquisition (SEO)
+- Branded impressions
+- Non-branded impressions
+- Organic clicks
+- Average position of target release queries
+- Indexed pages count
+
+### Activation (Landing engagement)
+- Hero CTA CTR
+- Platform card CTR by provider
+- Scroll depth (25/50/75/100)
+
+### Conversion (Owned audience)
+- Newsletter submit rate
+- Newsletter success rate
+- Cost per subscriber (if paid traffic is added)
+
+### Retention (Hook quality)
+- Returning visitors
+- Email open/click for drop announcements
+- Repeat session interval after a release
+
+---
+
+## 6) Implementation Backlog (Ticket-ready)
+
+1. Add `robots.txt` with sitemap reference.
+2. Add `sitemap.xml` for current URLs.
+3. Refactor schema to multi-node `@graph`.
+4. Add analytics event wrapper utility and emit conversion events.
+5. Add hero-level email CTA module.
+6. Add incentive microcopy for newsletter value proposition.
+7. Create release detail page template.
+8. Add social proof component.
+9. Add sticky mobile CTA.
+10. Add experiment flags for headline/CTA variants.
+
+---
+
+## 7) Quick-win copy hooks to test
+- **Hook A:** “First listen lives here. Drops hit this page before anywhere else.”
+- **Hook B:** “No soft drops. Just records that land heavy.”
+- **Hook C:** “Join the list for unreleased cuts + private drop alerts.”
+- **Hook D:** “If you found one track, wait till the next one.”
+
+---
+
+## 8) Notes for execution
+- Keep all SEO-critical tags server-rendered in static HTML (already aligned).
+- For external platform links, preserve clear tracking params where possible.
+- If custom domain is adopted, update canonical, OG URL, sitemap URLs, and structured data `url` fields in one release.

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://d-roc.vercel.app/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://d-roc.vercel.app/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
### Motivation
- Improve search discoverability and provide a prioritized roadmap to increase owned-audience conversions by auditing the landing page's SEO, funnel, and messaging hooks. 
- Provide immediate technical crawl guidance to search engines with minimal, safe assets while documenting recommended measurement and optimization steps for future work.

### Description
- Added a comprehensive audit and 90-day optimization plan at `docs/seo-funnel-hooks-audit.md` that includes current-state findings, gaps, phased implementation, KPI taxonomy, and a ticket-ready backlog. 
- Added a baseline crawler guidance file `robots.txt` that points to the sitemap to aid indexing. 
- Added a minimal `sitemap.xml` containing the homepage entry to seed Search Console and crawling. 
- No visual or runtime UI behavior was changed in the landing page as part of this update.

### Testing
- Ran the test suite with `npm test` and the Vitest run completed successfully. 
- All automated tests passed: 4 test files and 143 tests passed with no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69affe31504c8321b10aed6149c5a7ae)